### PR TITLE
Define unicode() for Python 3

### DIFF
--- a/simplestyle/styles.py
+++ b/simplestyle/styles.py
@@ -7,6 +7,11 @@ All classes and helpers dealing with styles
 
 from css import SimpleCSSParser, CSSEmptyDocumentError
 
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 class StyleError(Exception): pass
 class EmptyStyleError(StyleError): pass
 


### PR DESCRIPTION
unicode() was removed from Python 3 because all strs are Unicode.  This PR does not modify Python 2 functionality.